### PR TITLE
Update minimal CMake version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Set up the project
 project(filex

--- a/test/cmake/regression/CMakeLists.txt
+++ b/test/cmake/regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 cmake_policy(SET CMP0057 NEW)
 
 project(regression_test LANGUAGES C)

--- a/test/cmake/samples/CMakeLists.txt
+++ b/test/cmake/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 cmake_policy(SET CMP0057 NEW)
 
 project(samples LANGUAGES C)


### PR DESCRIPTION
Anything under 3.5 was breaking build scripts.

Discovered this after trying to build NetXDuo. Ran the `install.sh` script in the `netxduo/scripts/` folder, then realized it had updated CMake to 4.0+ and could no longer run the `build_nxd.sh` script because the FileX dependency build failed.