### PR TITLE
Add CMake support for Cortex M33

### DIFF
--- a/ports/cortex_m33/gnu/CMakeLists.txt
+++ b/ports/cortex_m33/gnu/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(${PROJECT_NAME} PRIVATE
+    # {{BEGIN_TARGET_SOURCES}}
+
+    # {{END_TARGET_SOURCES}}
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/inc
+)

--- a/ports/cortex_m33/gnu/inc/fx_port.h
+++ b/ports/cortex_m33/gnu/inc/fx_port.h
@@ -1,0 +1,23 @@
+/***************************************************************************
+ * Copyright (c) 2024 Microsoft Corporation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License which is available at
+ * https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: MIT
+ **************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** FileX Component                                                       */
+/**                                                                       */
+/**   Port Specific                                                       */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+/* Include the generic version of fx_port.h. */
+#include "../../../generic/inc/fx_port.h"


### PR DESCRIPTION
Add convenience CMake files for Cortex M33
similar to other Cortex Mx targets