### PR TITLE
Flagged six FileX APIs as deprecated

### DIFF
--- a/common/src/fx_directory_long_name_get.c
+++ b/common/src/fx_directory_long_name_get.c
@@ -29,6 +29,17 @@
 #include "fx_directory.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_directory_long_name_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a destination buffer length; writes up to FX_MAX_LONG_NAME_LEN bytes regardless of the caller's buffer size, risking a buffer overrun.
+ *
+ * WHAT TO DO: replace calls with fx_directory_long_name_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_directory_long_name_get() is deprecated. " \
+                "Use fx_directory_long_name_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -45,7 +56,8 @@
 /*    name. If there is no long file name, the short file name will be    */
 /*    returned.                                                           */
 /*                                                                        */
-/*    Note, this API is deprecated as fx_directory_long_name_get_extended */
+/*    DEPRECATED. Use fx_directory_long_name_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a destination buffer length; writes up to FX_MAX_LONG_NAME_LEN bytes regardless of the caller's buffer size, risking a buffer overrun.
 /*    should be used. The maximum written size to long_file_name could be */
 /*    FX_MAX_LONG_NAME_LEN.                                               */
 /*                                                                        */

--- a/common/src/fx_directory_short_name_get.c
+++ b/common/src/fx_directory_short_name_get.c
@@ -29,6 +29,17 @@
 #include "fx_directory.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_directory_short_name_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a destination buffer length; writes up to FX_MAX_SHORT_NAME_LEN bytes regardless of the caller's buffer size, risking a buffer overrun.
+ *
+ * WHAT TO DO: replace calls with fx_directory_short_name_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_directory_short_name_get() is deprecated. " \
+                "Use fx_directory_short_name_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -45,7 +56,8 @@
 /*    name. If the long file name is really a short file name, the short  */
 /*    file name will be returned.                                         */
 /*                                                                        */
-/*    Note, this API is deprecated as fx_directory_short_name_get_extended*/
+/*    DEPRECATED. Use fx_directory_short_name_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a destination buffer length; writes up to FX_MAX_SHORT_NAME_LEN bytes regardless of the caller's buffer size, risking a buffer overrun.
 /*    should be used. The maximum written size to short_file_name could   */
 /*    be FX_MAX_SHORT_NAME_LEN.                                           */
 /*                                                                        */

--- a/common/src/fx_media_volume_get.c
+++ b/common/src/fx_media_volume_get.c
@@ -32,6 +32,17 @@
 #include "fx_utility.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_media_volume_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a volume-name buffer length; writes up to 12 bytes regardless of the caller's buffer size, risking a buffer overrun.
+ *
+ * WHAT TO DO: replace calls with fx_media_volume_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_media_volume_get() is deprecated. " \
+                "Use fx_media_volume_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -47,7 +58,8 @@
 /*    This function reads the volume name stored in the media's boot      */
 /*    record or root directory.                                           */
 /*                                                                        */
-/*    Note, this API is deprecated as fx_media_volume_get_extended should */
+/*    DEPRECATED. Use fx_media_volume_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a volume-name buffer length; writes up to 12 bytes regardless of the caller's buffer size, risking a buffer overrun.
 /*    be used. The maximum written size to volume_name could be 12.       */
 /*                                                                        */
 /*  INPUT                                                                 */

--- a/common/src/fx_unicode_length_get.c
+++ b/common/src/fx_unicode_length_get.c
@@ -29,6 +29,17 @@
 #include "fx_unicode.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_unicode_length_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a buffer length; scans up to 256 bytes regardless of the actual buffer size, risking an overread.
+ *
+ * WHAT TO DO: replace calls with fx_unicode_length_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_unicode_length_get() is deprecated. " \
+                "Use fx_unicode_length_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -43,7 +54,8 @@
 /*                                                                        */
 /*    This function returns the length of the supplied unicode name.      */
 /*                                                                        */
-/*    Note, this API is deprecated as _fx_unicode_length_get_extended     */
+/*    DEPRECATED. Use fx_unicode_length_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a buffer length; scans up to 256 bytes regardless of the actual buffer size, risking an overread.
 /*    should be used. The maximum buffer size of unicode_name is 256.     */
 /*                                                                        */
 /*  INPUT                                                                 */

--- a/common/src/fx_unicode_name_get.c
+++ b/common/src/fx_unicode_name_get.c
@@ -29,6 +29,17 @@
 #include "fx_unicode.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_unicode_name_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a destination buffer length; writes up to FX_MAX_LONG_NAME_LEN*2 bytes regardless of the caller's buffer size, risking a buffer overrun.
+ *
+ * WHAT TO DO: replace calls with fx_unicode_name_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_unicode_name_get() is deprecated. " \
+                "Use fx_unicode_name_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -44,7 +55,8 @@
 /*    This function finds the unicode name associated with the supplied   */
 /*    short 8.3 name.                                                     */
 /*                                                                        */
-/*    Note, this API is deprecated as fx_unicode_name_get_extended should */
+/*    DEPRECATED. Use fx_unicode_name_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a destination buffer length; writes up to FX_MAX_LONG_NAME_LEN*2 bytes regardless of the caller's buffer size, risking a buffer overrun.
 /*    be used. The maximum written size to destination_unicode_name could */
 /*    be FX_MAX_LONG_NAME_LEN * 2.                                        */
 /*                                                                        */

--- a/common/src/fx_unicode_short_name_get.c
+++ b/common/src/fx_unicode_short_name_get.c
@@ -29,6 +29,17 @@
 #include "fx_unicode.h"
 
 
+/* DEPRECATION NOTICE
+ * fx_unicode_short_name_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: Does not accept a destination buffer length; writes up to 13 bytes regardless of the caller's buffer size, risking a buffer overrun.
+ *
+ * WHAT TO DO: replace calls with fx_unicode_short_name_get_extended(), passing the actual
+ * destination buffer size as an additional argument.
+ */
+#pragma message("fx_unicode_short_name_get() is deprecated. " \
+                "Use fx_unicode_short_name_get_extended() and pass the actual buffer size.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -44,7 +55,8 @@
 /*    This function finds the short name associated with the supplied     */
 /*    unicode name.                                                       */
 /*                                                                        */
-/*    Note, this API is deprecated as fx_unicode_short_name_get_extended  */
+/*    DEPRECATED. Use fx_unicode_short_name_get_extended() instead, passing the actual
+    destination buffer length. Does not accept a destination buffer length; writes up to 13 bytes regardless of the caller's buffer size, risking a buffer overrun.
 /*    should be used. The maximum written size to destination_short_name  */
 /*    could be 13.                                                        */
 /*                                                                        */


### PR DESCRIPTION
## Summary
Six FileX functions omit a destination buffer-length parameter and use a fixed or hardcoded limit. They can cause buffer overruns in the caller. Each has an `_extended` replacement that accepts an explicit buffer size.

| Deprecated | Replacement | Fixed limit |
|---|---|---|
| `fx_directory_long_name_get` | `fx_directory_long_name_get_extended` | `FX_MAX_LONG_NAME_LEN` |
| `fx_directory_short_name_get` | `fx_directory_short_name_get_extended` | `FX_MAX_SHORT_NAME_LEN` |
| `fx_media_volume_get` | `fx_media_volume_get_extended` | 12 |
| `fx_unicode_length_get` | `fx_unicode_length_get_extended` | 256 |
| `fx_unicode_name_get` | `fx_unicode_name_get_extended` | `FX_MAX_LONG_NAME_LEN*2` |
| `fx_unicode_short_name_get` | `fx_unicode_short_name_get_extended` | 13 |

## Changes
Added `#pragma message` compile-time warnings and updated DESCRIPTION blocks in all six source files.

## Companion
Docs: eclipse-threadx/rtos-docs-asciidoc#33 (pending)